### PR TITLE
montblanc: adapt sepolicy to myrom

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -144,6 +144,7 @@ BOARD_SEPOLICY_UNION += \
        hci_attach.te \
        init.te \
        iw.te \
+       mediaserver.te \
        modem-helpers.te \
        psccd.te \
        rild.te \

--- a/sepolicy/recovery.te
+++ b/sepolicy/recovery.te
@@ -1,4 +1,0 @@
-recovery_only(`
-  # Allow recovery to set permissive mode
-  permissive recovery;
-')


### PR DESCRIPTION
1) Include mediaserver.te in the sepolicy
2) Remove recovery.te (that wasn't included in sepolicy),
it should belong to vendor/myrom

Change-Id: Iac5000386f9141a44635426bb85f287641b0f4d9